### PR TITLE
Prepare package for PyPI publication as pythonstl v0.1.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,9 +10,12 @@ exclude =
     *.egg-info,
     .pytest_cache,
     .mypy_cache
+# E203: whitespace before ':'
+# W503: line break before binary operator
+# E501: line too long (handled by max-line-length)
 ignore = 
-    E203,  # whitespace before ':'
-    W503,  # line break before binary operator
-    E501   # line too long (handled by max-line-length)
+    E203,
+    W503,
+    E501
 per-file-ignores =
     __init__.py:F401,F403

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,16 +29,16 @@ jobs:
     
     - name: Run flake8
       run: |
-        flake8 pystl/ --count --show-source --statistics
+        flake8 pythonstl/ --count --show-source --statistics
     
     - name: Run mypy
       run: |
-        mypy pystl/ --ignore-missing-imports
+        mypy pythonstl/ --ignore-missing-imports
       continue-on-error: true
     
     - name: Run tests with coverage
       run: |
-        pytest tests/ --cov=pystl --cov-report=xml --cov-report=term
+        pytest tests/ --cov=pythonstl --cov-report=xml --cov-report=term
     
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A production-ready Python package that replicates C++ STL-style data structures using the **Facade Design Pattern**. PythonSTL provides clean, familiar interfaces for developers coming from C++ while maintaining Pythonic best practices.
 
-## 🎯 Features
+## Features
 
 - **C++ STL Compliance**: Exact method names and semantics matching C++ STL
 - **Facade Design Pattern**: Clean separation between interface and implementation
@@ -19,7 +19,7 @@ A production-ready Python package that replicates C++ STL-style data structures 
 - **Production Quality**: Proper error handling, PEP8 compliance, and extensive testing
 - **Zero Dependencies**: Core package has no external dependencies
 
-## 📦 Installation
+## Installation
 
 ```bash
 pip install pythonstl
@@ -33,7 +33,7 @@ cd STL
 pip install -e .
 ```
 
-## 🚀 Quick Start
+## Quick Start
 
 ```python
 from pythonstl import stack, queue, vector, stl_set, stl_map, priority_queue
@@ -87,7 +87,7 @@ pq_max.push(20)
 print(pq_max.top())  # 30
 ```
 
-## 📚 Data Structures
+## Data Structures
 
 ### Stack
 
@@ -224,7 +224,7 @@ Container adapter providing priority-based access.
 - `repr(pq)` - String representation
 - `pq1 == pq2` - Equality comparison
 
-## ⚡ Time Complexity Reference
+## Time Complexity Reference
 
 | Container | Operation | Complexity |
 |-----------|-----------|------------|
@@ -252,7 +252,7 @@ Container adapter providing priority-based access.
 | | pop() | O(log n) |
 | | top() | O(1) |
 
-## 🏗️ Architecture
+## Architecture
 
 PythonSTL follows the **Facade Design Pattern** with three layers:
 
@@ -276,7 +276,7 @@ This architecture ensures:
 - **Maintainability**: Easy to modify internals without breaking API
 - **Testability**: Each layer can be tested independently
 
-## 🔒 Thread Safety
+## Thread Safety
 
 **Important:** PythonSTL containers are **NOT thread-safe** by default. If you need to use them in a multi-threaded environment, you must provide your own synchronization (e.g., using `threading.Lock`).
 
@@ -292,7 +292,7 @@ def thread_safe_push(value):
         s.push(value)
 ```
 
-## 🎨 Design Decisions
+## Design Decisions
 
 ### Why Facade Pattern?
 
@@ -315,7 +315,7 @@ Full Python integration while maintaining STL compatibility:
 - Copy protocol support
 - Maintains backward compatibility
 
-## 📊 Benchmarks
+## Benchmarks
 
 PythonSTL provides benchmarks comparing performance against Python built-ins:
 
@@ -335,7 +335,7 @@ The facade pattern adds minimal overhead while providing:
 
 See `benchmarks/README.md` for detailed analysis.
 
-## 🧪 Testing
+## Testing
 
 Run the test suite:
 
@@ -350,7 +350,7 @@ pytest tests/
 pytest tests/ --cov=pythonstl --cov-report=html
 ```
 
-## 🛠️ Development
+## Development
 
 ### Setup
 
@@ -373,11 +373,11 @@ flake8 pythonstl/
 pytest && mypy pythonstl/ && flake8 pythonstl/
 ```
 
-## 📝 License
+## License
 
 MIT License - see LICENSE file for details.
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please:
 1. Fork the repository
@@ -386,12 +386,12 @@ Contributions are welcome! Please:
 4. Ensure all tests pass
 5. Submit a pull request
 
-## 📮 Contact
+## Contact
 
 - GitHub: [@AnshMNSoni](https://github.com/AnshMNSoni)
-- Issues: [GitHub Issues](https://github.com/AnshMNSoni/STL/issues)
+- Issues: [GitHub Issues](https://github.com/AnshMNSoni/PythonSTL/issues)
 
-## 🗺️ Roadmap
+## Roadmap
 
 Future enhancements:
 - Additional STL containers (deque, list, multiset, multimap)
@@ -402,4 +402,4 @@ Future enhancements:
 
 ---
 
-**PythonSTL v0.1.0** - Bringing C++ STL elegance to Python 🐍
+**PythonSTL v0.1.0** - Bringing C++ STL elegance to Python

--- a/README.md
+++ b/README.md
@@ -399,7 +399,3 @@ Future enhancements:
 - Custom allocators
 - Thread-safe variants
 - Performance optimizations
-
----
-
-**PythonSTL v0.1.0** - Bringing C++ STL elegance to Python


### PR DESCRIPTION
- Renamed package from pystl to pythonstl
- Updated all imports across 33+ files
- Created PyPI configuration files
- Version set to 0.1.0
- Build verified and ready for publication